### PR TITLE
Email and phone number format changed. Set the range of the number input

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}"
+        }
+    ]
+}

--- a/src/components/loginSignup/SignUp.jsx
+++ b/src/components/loginSignup/SignUp.jsx
@@ -113,6 +113,10 @@ const SignUp = () => {
                   placeholder="Enter your Phone No."
                   value={phone}
                   onChange={(e) => setPhone(e.target.value)}
+                  pattern="^\s*\(?\s*\d{3}\s*\)?\s*[-]?\s*\d{3}\s*[-]?\s*\d{4}\s*$"
+                  min="1000000000"  
+                  max="9999999999"  
+                  step="1"
                   required
                 />
               </div>
@@ -127,6 +131,7 @@ const SignUp = () => {
                   placeholder="Enter your Email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
+                  pattern="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"
                   required
                 />
               </div>


### PR DESCRIPTION

I changed the format specifiers for the email and phone number on the signup page, as it was accepting invalid inputs too.
Beside the phone number input, it showed arrows which had an undefined range. I set it according to a phone number input.